### PR TITLE
Keep ToggleChips the same color in the ActivitiesScreen regardless of on/off status

### DIFF
--- a/wear/src/main/java/com/example/util/simpletimetracker/presentation/components/ActivityChip.kt
+++ b/wear/src/main/java/com/example/util/simpletimetracker/presentation/components/ActivityChip.kt
@@ -76,7 +76,8 @@ fun ActivityChip(
         colors = ToggleChipDefaults.toggleChipColors(
             checkedStartBackgroundColor = color,
             checkedEndBackgroundColor = color,
-            uncheckedToggleControlColor = ToggleChipDefaults.SwitchUncheckedIconColor,
+            uncheckedStartBackgroundColor = color,
+            uncheckedEndBackgroundColor = color,
         ),
         onCheckedChange = {
             switchChecked = it


### PR DESCRIPTION
### Notes

Before: Activity ToggleChips are only colored when enabled.
After: Activity ToggleChips are always colored.

### Testing Done

Pulled down latest code from wearos branch, verified that turning activities on and off doesn't change the activity chip colors.