### PR TITLE
Update ActivitiesList UI to make tag selection optional

### DIFF
--- a/wear/src/main/java/com/example/util/simpletimetracker/presentation/components/ActivitiesList.kt
+++ b/wear/src/main/java/com/example/util/simpletimetracker/presentation/components/ActivitiesList.kt
@@ -6,12 +6,18 @@
  */
 package com.example.util.simpletimetracker.presentation.components
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.example.util.simpletimetracker.presentation.layout.ScaffoldedScrollingColumn
+import com.example.util.simpletimetracker.presentation.remember.rememberRPCClient
 import com.example.util.simpletimetracker.wearrpc.Activity
 import com.example.util.simpletimetracker.wearrpc.CurrentActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 @Composable
 fun ActivitiesList(
@@ -21,6 +27,10 @@ fun ActivitiesList(
     onDeselectActivity: (activity: Activity) -> Unit,
     onRefresh: () -> Unit,
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val rpcClient = rememberRPCClient()
+    val context = LocalContext.current
+
     ScaffoldedScrollingColumn {
         for (activity in activities) {
             val currentActivity = currentActivities.filter { it.id == activity.id }.getOrNull(0)
@@ -29,7 +39,34 @@ fun ActivitiesList(
                     activity,
                     startedAt = currentActivity?.startedAt,
                     tags = currentActivity?.tags ?: arrayOf(),
-                    onClick = { if (it) onSelectActivity(activity) else onDeselectActivity(activity) },
+                    onSelectActivity = {
+                        coroutineScope.launch(Dispatchers.Default) {
+                            val activityTags = rpcClient.queryTagsForActivity(activity.id)
+                            coroutineScope.launch(Dispatchers.Main) {
+                                if (activityTags.isNotEmpty()) {
+                                    onSelectActivity(activity)
+                                } else {
+                                    Toast.makeText(context, "Activity has no tags", Toast.LENGTH_SHORT).show()
+                                }
+                            }
+                        }
+                    },
+                    onSelectActivitySkipTagSelection = {
+                        coroutineScope.launch(Dispatchers.Default) {
+                            rpcClient.setCurrentActivities(
+                                currentActivities.plus(
+                                    CurrentActivity(
+                                        activity.id,
+                                        System.currentTimeMillis(),
+                                        arrayOf(),
+                                    ),
+                                ),
+                            )
+                        }
+                    },
+                    onDeselectActivity = {
+                        onDeselectActivity(activity)
+                    },
                 )
             }
         }
@@ -50,13 +87,13 @@ private fun Preview() {
         Activity(4321, "Sleep", "🛏️", "#0000FA"),
     )
     val currents = arrayOf(
-        CurrentActivity(id = 4321, startedAt = 1708241427000L, tags = arrayOf())
+        CurrentActivity(id = 4321, startedAt = 1708241427000L, tags = arrayOf()),
     )
     ActivitiesList(
         activities,
         currentActivities = currents,
         onSelectActivity = { /* `it` is the selected activity */ },
         onDeselectActivity = { /* `it` is the deselected activity */ },
-        onRefresh = { /* What to do when requesting a refresh */ }
+        onRefresh = { /* What to do when requesting a refresh */ },
     )
 }

--- a/wear/src/main/java/com/example/util/simpletimetracker/presentation/components/ActivityChip.kt
+++ b/wear/src/main/java/com/example/util/simpletimetracker/presentation/components/ActivityChip.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
@@ -18,10 +19,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.SplitToggleChip
 import androidx.wear.compose.material.Switch
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
+import com.example.util.simpletimetracker.presentation.remember.rememberRPCClient
 import com.example.util.simpletimetracker.presentation.theme.hexCodeToColor
 import com.example.util.simpletimetracker.wearrpc.Activity
 import com.example.util.simpletimetracker.wearrpc.Tag
@@ -35,8 +37,13 @@ fun ActivityChip(
     activity: Activity,
     startedAt: Long? = null,
     tags: Array<Tag> = arrayOf(),
-    onClick: (Boolean) -> Unit = {},
+    onSelectActivity: () -> Unit = {},
+    onSelectActivitySkipTagSelection: () -> Unit = {},
+    onDeselectActivity: () -> Unit = {},
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val rpcClient = rememberRPCClient()
+
     val briefIcon = if (activity.icon.startsWith("ic_")) {
         "?"
     } else {
@@ -57,7 +64,7 @@ fun ActivityChip(
         .fillMaxWidth(0.9f)
         .padding(top = 10.dp)
     var switchChecked by remember { mutableStateOf(startedAt != null) }
-    ToggleChip(
+    SplitToggleChip(
         modifier = modifier,
         label = {
             Text(
@@ -73,17 +80,21 @@ fun ActivityChip(
                 null
             }
         },
-        colors = ToggleChipDefaults.toggleChipColors(
-            checkedStartBackgroundColor = color,
-            checkedEndBackgroundColor = color,
-            uncheckedStartBackgroundColor = color,
-            uncheckedEndBackgroundColor = color,
+        colors = ToggleChipDefaults.splitToggleChipColors(
+            backgroundColor = color,
         ),
         onCheckedChange = {
+            if (it) {
+                onSelectActivitySkipTagSelection()
+            } else {
+                onDeselectActivity()
+            }
             switchChecked = it
-            onClick(switchChecked)
         },
         checked = switchChecked,
+        onClick = {
+            onSelectActivity()
+        },
         toggleControl = {
             Switch(
                 checked = switchChecked,

--- a/wear/src/main/java/com/example/util/simpletimetracker/presentation/screens/ActivitiesScreen.kt
+++ b/wear/src/main/java/com/example/util/simpletimetracker/presentation/screens/ActivitiesScreen.kt
@@ -11,7 +11,6 @@ import com.example.util.simpletimetracker.presentation.remember.rememberActiviti
 import com.example.util.simpletimetracker.presentation.remember.rememberCurrentActivities
 import com.example.util.simpletimetracker.wearrpc.Activity
 
-
 @Composable
 fun ActivitiesScreen(onSelectActivity: (activityId: Long) -> Unit) {
     val (activities, refreshActivities) = rememberActivities()


### PR DESCRIPTION
### Notes

https://github.com/thehale/SimpleTimeTracker-WearOS/issues/12 
https://github.com/thehale/SimpleTimeTracker-WearOS/issues/13

ActivityChips now SplitToggleChips so tags can be optionally set at enable time.

Clicking on the "button" part of the chip will either navigate to the TagsScreen or raise a toast saying "Activity has no tags", depending on the result of rpc.queryTagsForActivity, which is invoked at tap-time.

Clicking on the "switch" part of the chip will turn the activity on or off regardless of whether the activity has any tags available.